### PR TITLE
add index==0 because ==1 is the metadata node, i think.

### DIFF
--- a/98-hdmi2usb-opsis.rules
+++ b/98-hdmi2usb-opsis.rules
@@ -18,7 +18,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="2a19", ATTRS{idProduct}=="5442", \
 SUBSYSTEM=="tty", ATTRS{idVendor}=="2a19", ATTRS{idProduct}=="5442", \
 	ENV{ID_HDMI2USB}:="1", ENV{ID_HDMI2USB_BOARD}:="opsis", ENV{ID_HDMI2USB_TTY}:=""
 
-SUBSYSTEM=="video4linux", ATTRS{idVendor}=="2a19", ATTRS{idProduct}=="5442", \
+SUBSYSTEM=="video4linux", ATTRS{idVendor}=="2a19", ATTRS{idProduct}=="5442", ATTR{index}=="0", \
 	ENV{ID_HDMI2USB}:="1", ENV{ID_HDMI2USB_BOARD}:="opsis"
 
 # TOFE LowSpeedIO board


### PR DESCRIPTION
Linux kernel/udev now creates 2 nodes, one for video stream, one for metadata.

bug report against Opsis:
https://salsa.debian.org/debconf-video-team/ansible/-/issues/41

more general:
https://bugs.debian.org/930860

This PR ignores the metadata node for Opsis.  

it is possible a better fix is in:
https://github.com/systemd/systemd/blob/master/src/udev/v4l_id/v4l_id.c#L75-L76
```
  if ((capabilities & V4L2_CAP_VIDEO_CAPTURE) > 0 ||
                    (capabilities & V4L2_CAP_VIDEO_CAPTURE_MPLANE) > 0)
                        printf("capture:");
```

